### PR TITLE
Scaladocs and updated README, also include an aggregator example

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,38 +1,60 @@
-noether
+Noether
 =======
-
 
 [![Build Status](https://travis-ci.org/spotify/noether.svg?branch=master)](https://travis-ci.org/spotify/noether)
 [![codecov.io](https://codecov.io/github/spotify/noether/coverage.svg?branch=master)](https://codecov.io/github/spotify/noether?branch=master)
 [![GitHub license](https://img.shields.io/github/license/spotify/noether.svg)](./LICENSE)
 [![Maven Central](https://img.shields.io/maven-central/v/com.spotify/noether-core_2.12.svg)](https://maven-badges.herokuapp.com/maven-central/com.spotify/noether-core_2.12)
 
-This library contains a set of monoids and aggregators for ML oriented tasks in Scala. The library builds upon the monoids and aggregators found in the [Algebird](https://github.com/twitter/algebird) library.
+> [Emmy Noether](https://en.wikipedia.org/wiki/Emmy_Noether) was a German mathematician known for her landmark contributions to abstract algebra and theoretical physics. 
+
+Noether is a collection of Machine Learning tools targeted at the JVM and Scala.
+It relies heavily on the [Algebird](https://github.com/twitter/algebird) library especially for Aggregators.
 
 # Aggregators
 
-Currently the library has metric driven aggregators which is broken down below.
+Aggregators enable creation of reusable and composable aggregation functions. Most Machine Learning loss functions and metrics can be 
+decomposed into a single aggregator.  This becomes useful when a model produces a set of predictions and one or more metrics are needed
+to be computed on this collection.
 
-## Metrics
+Below is an example for a binary classification task. Algebird's MultiAggregator can be used to combine multiple metrics into a 
+single callable aggregator.
 
-These metrics are split between different types of predictions. The simple case is binary but some multi-class predictions are provided also.
+```scala
+val multiAggregator =
+  MultiAggregator(AUC(ROC), AUC(PR), ClassificationReport(), BinaryConfusionMatrix())
+    .andThenPresent{case (roc, pr, report, cm) =>
+      (roc, pr, report.accuracy, report.recall, report.precision, cm(1, 1), cm(0, 0))
+    }
 
-### Binary
+val predictions = List(Prediction(false, 0.1), Prediction(false, 0.6), Prediction(true, 0.9))
 
-These Aggregators are meant for a single binary label and a score that is a valid probability.
+println(multiAggregator(predictions))
+```
 
-1. Confusion Matrix
-1. Precision Recall Curve
-1. ROC Curve
-1. AUC ROC
-1. AUC PR
+## Prediction Object
 
-### Multi-class
+Most aggregators take a single parameterized class called Prediction as input to the aggregator. However the type of
+the prediction object differ based on the aggregator. In the above example each binary classifier takes a prediction 
+of type `Prediction[Boolean, Double]` where the first type is the label and the second in the predicted score.
 
-These Aggregators are meant for a multi-class setup where the scores a distribution over labels and the label is an int representing the label.
+Other aggregators will takes slightly different types such as the Error Rate Aggregator which expects `Prediction[Int, List[Double]]`
+where the types are label and a list of scores.
 
-1. Error Rate
-1. Log Loss
+## Available Aggregators
+
+See the docs on each aggregator for a more detailed walk-through on the functionality and the return objects.
+
+1. ConfusionMatrix
+    1.  Includes a special BinaryConfusionMatrix case to make composition easier with the other binary classification metrics.
+2. AUC
+    1. Supports both ROC and PR
+3. ClassificationReport
+    1. Returns a list of summary metrics for a binary classification problem.
+4. LogLoss
+    1. Available for multiclass. Returns the total log loss for the predictions.
+5. ErrorRateSummary
+    1. Available for multiclass. Returns the proportion of misclassified predictions.w      
 
 # License
 

--- a/build.sbt
+++ b/build.sbt
@@ -54,10 +54,10 @@ val noPublishSettings = Seq(
 )
 
 lazy val root: Project = Project("root",file(".")
-).settings(commonSettings ++ noPublishSettings).aggregate(core)
+).settings(commonSettings ++ noPublishSettings).aggregate(noetherCore, noetherExamples)
 
-lazy val core: Project = Project(
-  "core",
+lazy val noetherCore: Project = Project(
+  "noether-core",
   file("core")
 ).settings(
   commonSettings,
@@ -69,3 +69,12 @@ lazy val core: Project = Project(
     "org.scalatest" %% "scalatest" %  scalaTestVersion
   )
 )
+
+lazy val noetherExamples: Project = Project(
+  "noether-examples",
+  file("examples")
+).settings(
+  commonSettings,
+  moduleName := "noether-examples",
+  description := "Noether Examples"
+).dependsOn(noetherCore)

--- a/core/src/main/scala/com/spotify/noether/BinaryConfusionMatrix.scala
+++ b/core/src/main/scala/com/spotify/noether/BinaryConfusionMatrix.scala
@@ -1,0 +1,22 @@
+package com.spotify.noether
+
+import breeze.linalg.DenseMatrix
+import com.twitter.algebird.{Aggregator, Semigroup}
+
+/**
+ * Special Case for a Binary Confusion Matrix to make it easier to compose with other
+ * binary aggregators
+ *
+ * @param threshold Threshold to apply on predictions
+ */
+case class BinaryConfusionMatrix(threshold: Double = 0.5)
+  extends Aggregator[Prediction[Boolean, Double], Map[(Int, Int), Long], DenseMatrix[Long]]{
+  private val confusionMatrix = ConfusionMatrix(Seq(0, 1))
+
+  def prepare(input: Prediction[Boolean, Double]): Map[(Int, Int), Long] = {
+    val pred = Prediction(if(input.actual) 1 else 0, if(input.predicted > threshold) 1 else 0)
+    confusionMatrix.prepare(pred)
+  }
+  def semigroup: Semigroup[Map[(Int, Int), Long]] = confusionMatrix.semigroup
+  def present(m: Map[(Int, Int), Long]): DenseMatrix[Long] = confusionMatrix.present(m)
+}

--- a/core/src/main/scala/com/spotify/noether/ClassificationReport.scala
+++ b/core/src/main/scala/com/spotify/noether/ClassificationReport.scala
@@ -18,15 +18,32 @@
 package com.spotify.noether
 import com.twitter.algebird.{Aggregator, Semigroup}
 
-final case class Scores(mcc: Double,
+/**
+ * Classification Report
+ *
+ * @param mcc <a href="https://en.wikipedia.org/wiki/Matthews_correlation_coefficient"> Matthews Correlation Coefficient </a>
+ * @param fscore <a href="https://en.wikipedia.org/wiki/F1_score"> f-score </a>
+ * @param precision <a href="https://en.wikipedia.org/wiki/Precision_and_recall"> Precision </a>
+ * @param recall <a href="https://en.wikipedia.org/wiki/Precision_and_recall"> Recall </a>
+ * @param accuracy <a href="https://en.wikipedia.org/wiki/Accuracy_and_precision"> Accuracy </a>
+ * @param fpr <a href="https://en.wikipedia.org/wiki/False_positive_rate"> False Positive Rate </a>
+ */
+final case class Report(mcc: Double,
                         fscore: Double,
                         precision: Double,
                         recall: Double,
                         accuracy: Double,
                         fpr: Double)
 
-final case class ClassificationAggregator(threshold: Double = 0.5, beta: Double = 1.0)
-  extends Aggregator[Prediction[Boolean, Double], Map[(Int, Int), Long], Scores] {
+/**
+ * Generate a Classification Report for a collection of binary predictions.
+ * The output of this aggregator will be a [[Report]] object.
+ *
+ * @param threshold Threshold to apply to get the predictions.
+ * @param beta Beta parameter used in the f-score calculation.
+ */
+final case class ClassificationReport(threshold: Double = 0.5, beta: Double = 1.0)
+  extends Aggregator[Prediction[Boolean, Double], Map[(Int, Int), Long], Report] {
 
   private val aggregator = ConfusionMatrix(Seq(0, 1))
 
@@ -37,7 +54,7 @@ final case class ClassificationAggregator(threshold: Double = 0.5, beta: Double 
 
   def semigroup: Semigroup[Map[(Int, Int), Long]] = aggregator.semigroup
 
-  def present(m: Map[(Int, Int), Long]): Scores = {
+  def present(m: Map[(Int, Int), Long]): Report = {
     val mat = aggregator.present(m)
 
     val fp = mat(1, 0).toDouble
@@ -67,6 +84,6 @@ final case class ClassificationAggregator(threshold: Double = 0.5, beta: Double 
       (1 + betaSqr) * ((precision*recall) / fScoreDenom)
     } else { 1.0 }
 
-    Scores(mcc, fscore, precision, recall, accuracy, fpr)
+    Report(mcc, fscore, precision, recall, accuracy, fpr)
   }
 }

--- a/core/src/main/scala/com/spotify/noether/ConfusionMatrix.scala
+++ b/core/src/main/scala/com/spotify/noether/ConfusionMatrix.scala
@@ -20,7 +20,12 @@ package com.spotify.noether
 import breeze.linalg.DenseMatrix
 import com.twitter.algebird.{Aggregator, Semigroup}
 
-
+/**
+ * Generic Consfusion Matrix Aggregator for any dimension.
+ * Thresholds must be applied to make a prediction prior to using this aggregator.
+ *
+ * @param labels List of possible label values
+ */
 final case class ConfusionMatrix(labels: Seq[Int])
   extends Aggregator[Prediction[Int, Int], Map[(Int, Int), Long], DenseMatrix[Long]] {
 

--- a/core/src/main/scala/com/spotify/noether/ErrorRateSummary.scala
+++ b/core/src/main/scala/com/spotify/noether/ErrorRateSummary.scala
@@ -19,6 +19,9 @@ package com.spotify.noether
 
 import com.twitter.algebird.{Aggregator, Semigroup}
 
+/**
+ * Measurement of what percentage of values were predicted incorrectly.
+ */
 case object ErrorRateSummary
   extends Aggregator[Prediction[Int, List[Double]], (Double, Long), Double] {
   def prepare(input: Prediction[Int, List[Double]]): (Double, Long) = {

--- a/core/src/main/scala/com/spotify/noether/LogLoss.scala
+++ b/core/src/main/scala/com/spotify/noether/LogLoss.scala
@@ -19,6 +19,9 @@ package com.spotify.noether
 
 import com.twitter.algebird.{Aggregator, Semigroup}
 
+/**
+ * <a href="http://wiki.fast.ai/index.php/Log_Loss">LogLoss of the predictions.</a>
+ */
 case object LogLoss
   extends Aggregator[Prediction[Int, List[Double]], (Double, Long), Double] {
   def prepare(input: Prediction[Int, List[Double]]): (Double, Long) =

--- a/core/src/main/scala/com/spotify/noether/Prediction.scala
+++ b/core/src/main/scala/com/spotify/noether/Prediction.scala
@@ -17,6 +17,14 @@
 
 package com.spotify.noether
 
+/**
+ * Generic Prediction Object used by most aggregators
+ *
+ * @param actual Real value for this entry.  Also normally seen as label.
+ * @param predicted Predicted value.  Can be a class or a score depending on the aggregator.
+ * @tparam L Type of the Real Value
+ * @tparam S Type of the Predicted Value
+ */
 final case class Prediction[L, S](actual: L, predicted: S) {
   override def toString: String = s"$actual,$predicted"
 }

--- a/core/src/test/scala/com/spotify/noether/AUCTest.scala
+++ b/core/src/test/scala/com/spotify/noether/AUCTest.scala
@@ -28,10 +28,10 @@ class AUCTest extends AggregatorTest {
     ).map{case(s, pred) => Prediction(pred, s)}
 
   it should "return ROC AUC" in {
-    assert(run(AUCAggregator(ROC, samples=50))(data) === 0.7)
+    assert(run(AUC(ROC, samples=50))(data) === 0.7)
   }
 
   it should "return PR AUC" in {
-    assert(run(AUCAggregator(PR, samples=50))(data) === 0.83)
+    assert(run(AUC(PR, samples=50))(data) === 0.83)
   }
 }

--- a/core/src/test/scala/com/spotify/noether/BinaryConfusionMatrixTest.scala
+++ b/core/src/test/scala/com/spotify/noether/BinaryConfusionMatrixTest.scala
@@ -1,0 +1,18 @@
+package com.spotify.noether
+
+import org.scalactic.TolerantNumerics
+
+class BinaryConfusionMatrixTest extends AggregatorTest {
+  it should "return correct scores" in {
+    val data = List(
+      (false, 0.1), (false, 0.6), (false, 0.2), (true, 0.2), (true, 0.8), (true, 0.7), (true, 0.6)
+    ).map{case(pred, s) => Prediction(pred, s)}
+
+    val matrix = run(BinaryConfusionMatrix())(data)
+
+    assert(matrix(1, 1) === 3L)
+    assert(matrix(0, 1) === 1L)
+    assert(matrix(1, 0) === 1L)
+    assert(matrix(0, 0) === 2L)
+  }
+}

--- a/core/src/test/scala/com/spotify/noether/ClassificationReportTest.scala
+++ b/core/src/test/scala/com/spotify/noether/ClassificationReportTest.scala
@@ -27,7 +27,7 @@ class ClassificationReportTest extends AggregatorTest {
       (0.1, false), (0.1, true), (0.4, false), (0.6, false), (0.6, true), (0.6, true), (0.8, true)
     ).map{case(s, pred) => Prediction(pred, s)}
 
-    val score = run(ClassificationAggregator())(data)
+    val score = run(ClassificationReport())(data)
 
     assert(score.recall === 0.75)
     assert(score.precision === 0.75)

--- a/core/src/test/scala/com/spotify/noether/ConfusionMatrixTest.scala
+++ b/core/src/test/scala/com/spotify/noether/ConfusionMatrixTest.scala
@@ -21,8 +21,6 @@ import breeze.linalg.DenseMatrix
 import org.scalactic.TolerantNumerics
 
 class ConfusionMatrixTest extends AggregatorTest {
-  private implicit val doubleEq = TolerantNumerics.tolerantDoubleEquality(0.1)
-
   it should "return correct confusion matrix" in {
     val data =
       List(

--- a/examples/src/main/scala/com/spotify/noether/AggregatorExample.scala
+++ b/examples/src/main/scala/com/spotify/noether/AggregatorExample.scala
@@ -1,0 +1,19 @@
+package com.spotify.noether
+
+import com.twitter.algebird.MultiAggregator
+
+object AggregatorExample {
+  def main(args: Array[String]): Unit = {
+    val multiAggregator =
+      MultiAggregator(AUC(ROC), AUC(PR), ClassificationReport(), BinaryConfusionMatrix())
+        .andThenPresent{case (roc, pr, report, cm) =>
+          (roc, pr, report.accuracy, report.recall, report.precision, cm(1, 1), cm(0, 0))
+        }
+
+    val predictions = List(Prediction(false, 0.1), Prediction(false, 0.6), Prediction(true, 0.9))
+
+    // scalastyle:off regex
+    println(multiAggregator.apply(predictions))
+    // scalastyle:on regex
+  }
+}

--- a/examples/src/test/scala/com/spotify/noether/AggregatorExampleTest.scala
+++ b/examples/src/test/scala/com/spotify/noether/AggregatorExampleTest.scala
@@ -1,0 +1,9 @@
+package com.spotify.noether
+
+import org.scalatest.{FlatSpec, Matchers}
+
+class AggregatorExampleTest extends FlatSpec with Matchers {
+  it should "not fail when executing example" in {
+    AggregatorExample.main(Array.empty)
+  }
+}


### PR DESCRIPTION
Few updates in this PR, mostly around documentation and examples.

1. Add scaladocs to each aggregator.
2. Add an example main method for a binary classification task.
3. Add back in a Binary Confusion Matrix to save on need a function for a common binary prediction task.
4.  Create a new subproject only for examples.