### PR TITLE
Split curve and auc aggregators

### DIFF
--- a/core/src/main/scala/com/spotify/noether/AUC.scala
+++ b/core/src/main/scala/com/spotify/noether/AUC.scala
@@ -20,22 +20,23 @@ package com.spotify.noether
 import breeze.linalg._
 import com.twitter.algebird.{Aggregator, Semigroup}
 
-private[noether] case class Curve(cm: List[Map[(Int, Int), Long]])
+case class MetricCurve(cm: List[Map[(Int, Int), Long]]) extends Serializable
+
+case class MetricCurvePoint(x: Double, y: Double) extends Serializable
 
 private[noether] object AreaUnderCurve {
-  def trapezoid(points: Seq[(Double, Double)]): Double = {
-    require(points.length == 2)
+  def trapezoid(points: Seq[MetricCurvePoint]): Double = {
     val x = points.head
     val y = points.last
-    (y._1 - x._1) * (y._2 + x._2) / 2.0
+    (y.x - x.x) * (y.y + x.y) / 2.0
   }
 
-  def of(curve: List[(Double, Double)]): Double = {
+  def of(curve: List[MetricCurvePoint]): Double = {
     curve.toIterator
       .sliding(2)
       .withPartial(false)
       .aggregate(0.0)(
-        seqop = (auc: Double, points: Seq[(Double, Double)]) => auc + trapezoid(points),
+        seqop = (auc: Double, points: Seq[MetricCurvePoint]) => auc + trapezoid(points),
         combop = _ + _
       )
   }
@@ -61,6 +62,53 @@ case object ROC extends AUCMetric
 case object PR extends AUCMetric
 
 /**
+ * Compute a series of points for a collection of predictions.
+ *
+ * Internally a linspace is defined using the given number of [[samples]]. Each point in the
+ * linspace represents a threshold which is used to build a confusion matrix. The (x,y) location
+ * of the line is then returned.
+ *
+ * [[AUCMetric]] which is given to the aggregate selects the function to apply on
+ * the confusion matrix prior to the AUC calculation.
+ *
+ * @param metric  Which function to apply on the confusion matrix.
+ * @param samples Number of samples to use for the curve definition.
+ */
+case class Curve(metric: AUCMetric, samples: Int = 100)
+  extends Aggregator[Prediction[Boolean, Double], MetricCurve, List[MetricCurvePoint]] {
+
+  private lazy val thresholds = linspace(0.0, 1.0, samples)
+  private lazy val aggregators =
+    thresholds.data.map(ClassificationReport(_)).toList
+
+  def prepare(input: Prediction[Boolean, Double]): MetricCurve =
+    MetricCurve(aggregators.map(_.prepare(input)))
+
+  def semigroup: Semigroup[MetricCurve] = {
+    val sg = ClassificationReport().semigroup
+    Semigroup.from {
+      case (l, r) =>
+        MetricCurve(l.cm.zip(r.cm).map { case (cl, cr) => sg.plus(cl, cr) })
+    }
+  }
+
+  def present(c: MetricCurve): List[MetricCurvePoint] = {
+    val total = c.cm.map { matrix =>
+      val scores = ClassificationReport().present(matrix)
+      metric match {
+        case ROC => MetricCurvePoint(scores.fpr, scores.recall)
+        case PR  => MetricCurvePoint(scores.recall, scores.precision)
+      }
+    }.reverse
+
+    metric match {
+      case ROC => total ++ List(MetricCurvePoint(1.0, 1.0))
+      case PR  => List(MetricCurvePoint(0.0, 1.0)) ++ total
+    }
+  }
+}
+
+/**
  * Compute the "Area Under the Curve" for a collection of predictions. Uses the Trapezoid method to
  * compute the area.
  *
@@ -75,37 +123,9 @@ case object PR extends AUCMetric
  * @param samples Number of samples to use for the curve definition.
  */
 case class AUC(metric: AUCMetric, samples: Int = 100)
-    extends Aggregator[Prediction[Boolean, Double], Curve, Double] {
-
-  private lazy val thresholds = linspace(0.0, 1.0, samples)
-  private lazy val aggregators =
-    thresholds.data.map(ClassificationReport(_)).toList
-
-  def prepare(input: Prediction[Boolean, Double]): Curve =
-    Curve(aggregators.map(_.prepare(input)))
-
-  def semigroup: Semigroup[Curve] = {
-    val sg = ClassificationReport().semigroup
-    Semigroup.from {
-      case (l, r) =>
-        Curve(l.cm.zip(r.cm).map { case (cl, cr) => sg.plus(cl, cr) })
-    }
-  }
-
-  def present(c: Curve): Double = {
-    val total = c.cm.map { matrix =>
-      val scores = ClassificationReport().present(matrix)
-      metric match {
-        case ROC => (scores.fpr, scores.recall)
-        case PR  => (scores.recall, scores.precision)
-      }
-    }.reverse
-
-    val combined = metric match {
-      case ROC => total ++ List((1.0, 1.0))
-      case PR  => List((0.0, 1.0)) ++ total
-    }
-
-    AreaUnderCurve.of(combined)
-  }
+  extends Aggregator[Prediction[Boolean, Double], MetricCurve, Double] {
+  private val curve = Curve(metric, samples)
+  def prepare(input: Prediction[Boolean, Double]): MetricCurve = curve.prepare(input)
+  def semigroup: Semigroup[MetricCurve] = curve.semigroup
+  def present(c: MetricCurve): Double = AreaUnderCurve.of(curve.present(c))
 }

--- a/core/src/test/scala/com/spotify/noether/AUCTest.scala
+++ b/core/src/test/scala/com/spotify/noether/AUCTest.scala
@@ -40,4 +40,23 @@ class AUCTest extends AggregatorTest {
   it should "return PR AUC" in {
     assert(run(AUC(PR, samples = 50))(data) === 0.83)
   }
+
+  it should "return points of a PR Curve" in {
+    val expected = List(
+      (0.0,1.0), (0.0,1.0), (0.25,1.0), (0.75,0.75), (0.75,0.6), (1.0,0.5714285714285714)
+    ).map{case(a, b) => MetricCurvePoint(a, b)}
+    assert(run(Curve(PR, samples = 5))(data) == expected)
+  }
+
+  it should "return points of a ROC Curve" in {
+    val expected = List(
+      (0.0,0.0),
+      (0.0,0.25),
+      (0.3333333333333333,0.75),
+      (0.6666666666666666,0.75),
+      (1.0,1.0),
+      (1.0,1.0)
+    ).map{case(a, b) => MetricCurvePoint(a, b)}
+    assert(run(Curve(ROC, samples = 5))(data) == expected)
+  }
 }


### PR DESCRIPTION
Sometimes people want access to the curve itself and not just the AUC.  This makes it optional to compute just the AUC or Curve.