### PR TITLE
Bump version for next iteration

### DIFF
--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.2-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"


### PR DESCRIPTION
Reason: Some binary incompatibilities introduced in the latest changes.

There some binary incompatibilities.