### PR TITLE
Multi-list aggregator

### DIFF
--- a/core/src/main/scala/com/spotify/noether/MultiListAggregator.scala
+++ b/core/src/main/scala/com/spotify/noether/MultiListAggregator.scala
@@ -1,0 +1,36 @@
+package com.spotify.noether
+
+import com.twitter.algebird.{Aggregator, Semigroup}
+
+/**
+ * Aggregator which combines an unbounded list of other aggregators.
+ * Each aggregator in the list is tagged by a string. The string(aka name) could be used to
+ * retrieve the aggregated value from the Map emitted by the "present" function.
+ */
+object MultiListAggregator {
+
+  def apply[A, B, C](aggregatorsMap: List[(String, Aggregator[A, B, C])])
+  : Aggregator[A, List[B], Map[String, C]] = {
+    val aggregators = aggregatorsMap.collect { case (_ , v) => v }
+
+    new Aggregator[A, List[B], Map[String, C]] {
+      def prepare(input: A): List[B] =
+        aggregators.map(_.prepare(input))
+
+      def semigroup: Semigroup[List[B]] = new Semigroup[List[B]] {
+        def plus(x: List[B], y: List[B]): List[B] =
+          x.zip(y).zip(aggregators).map {
+            case ((a, b), agg) => agg.semigroup.plus(a, b)
+          }
+      }
+
+      def present(reduction: List[B]): Map[String, C] = Map(aggregators
+        .zip(reduction)
+        .zip(aggregatorsMap.collect { case (k, _) => k })
+        .map {
+          case ((aggregator, reduction), aggKey) =>
+            aggKey -> aggregator.present(reduction)
+        }: _*)
+    }
+  }
+}

--- a/examples/src/test/scala/com/spotify/noether/MultiListAggregatorTests.scala
+++ b/examples/src/test/scala/com/spotify/noether/MultiListAggregatorTests.scala
@@ -1,0 +1,25 @@
+package com.spotify.noether
+
+import com.twitter.algebird._
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.must.Matchers._
+
+class MultiListAggregatorTests extends AnyFlatSpec {
+
+  it must "aggregate into a list of individual aggregator results" in {
+
+    val multiListAgg = MultiListAggregator.apply[Long, Long, Long](List(
+      "min"  -> Aggregator.min,
+      "max"  -> Aggregator.max,
+      "size" -> Aggregator.size
+    ))
+
+    val result = multiListAgg(List(0, 1, 2, 3, 4, 5))
+
+    result("min") mustBe 0L
+    result("max") mustBe 5L
+    result("size") mustBe 6L
+  }
+
+}
+


### PR DESCRIPTION
We started using `noether` in one of our projects. In our case we have dozens of metrics to compute and the approach with using `MultiAggregator` doesn't really scale, because `MultiAggregator` returns a tuple with dozens of metrics and we need to pattern match it to extract all metrics. 

The PR adds `MultiListAggregator` which is designed to combine an unbounded list of other aggregators. Each aggregator in the list is tagged by a string. The string(aka name) could be used to retrieve the aggregated value from the Map emitted by the "present" function. Here is the usage example:

```scala
  it must "aggregate into a list of individual aggregator results" in {

    val multiListAgg = MultiListAggregator.apply[Long, Long, Long](List(
      "min"  -> Aggregator.min,
      "max"  -> Aggregator.max,
      "size" -> Aggregator.size
    ))

    val result = multiListAgg(List(0, 1, 2, 3, 4, 5))

    result("min") mustBe 0L
    result("max") mustBe 5L
    result("size") mustBe 6L
  }
```